### PR TITLE
Add standard html boilerplate

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>About The USL</title>
+    <meta charset="utf-8" />
+    <meta
+      content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+      name="viewport" />
+    <meta content="UniversalScammerList" property="og:site_name" />
+    <meta content="website" propety="og:type" />
+    <meta content="Learn about the Universal Scammer List" property="og:title" />
+    <meta
+      content="The system supporting a collection of subreddits who agree to work together to limit the impact that those who have scammed"
+      property="og:description" />
+    <meta content="https://RegExrTech.github.io/about" property="og:url" />
     <link rel="stylesheet" href="static/css/header.css" />
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title>Search</title>
+    <title>UniversalScammerList - Search</title>
+    <meta charset="utf-8" />
+    <meta
+      content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+      name="viewport" />
+    <meta content="UniversalScammerList" property="og:site_name" />
+    <meta content="website" propety="og:type" />
+    <meta content="Search the Universal Scammer List" property="og:title" />
+    <meta
+      content="The system supporting a collection of subreddits who agree to work together to limit the impact that those who have scammed"
+      property="og:description" />
+    <meta content="https://RegExrTech.github.io" property="og:url" />
     <link rel="stylesheet" href="static/css/header.css" />
   </head>
 

--- a/start.html
+++ b/start.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Getting Started with The USL</title>
+    <meta charset="utf-8" />
+    <meta
+      content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+      name="viewport" />
+    <meta content="UniversalScammerList" property="og:site_name" />
+    <meta content="website" propety="og:type" />
+    <meta content="Get started with the Universal Scammer List" property="og:title" />
+    <meta
+      content="The system supporting a collection of subreddits who agree to work together to limit the impact that those who have scammed"
+      property="og:description" />
+    <meta content="https://RegExrTech.github.io/start" property="og:url" />
     <link rel="stylesheet" href="static/css/header.css" />
   </head>
   <body>

--- a/subreddits.html
+++ b/subreddits.html
@@ -1,8 +1,19 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Participants</title>
     <link rel="stylesheet" href="static/css/header.css" />
+    <meta charset="utf-8" />
+    <meta
+      content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+      name="viewport" />
+    <meta content="UniversalScammerList" property="og:site_name" />
+    <meta content="website" propety="og:type" />
+    <meta content="View the subreddits in the Universal Scammer List" property="og:title" />
+    <meta
+      content="The system supporting a collection of subreddits who agree to work together to limit the impact that those who have scammed"
+      property="og:description" />
+    <meta content="https://RegExrTech.github.io/subreddits" property="og:url" />
   </head>
 
   <body>

--- a/tags.html
+++ b/tags.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Tags</title>
+    <meta charset="utf-8" />
+    <meta
+      content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+      name="viewport" />
+    <meta content="UniversalScammerList" property="og:site_name" />
+    <meta content="website" propety="og:type" />
+    <meta content="View the tags in the Universal Scammer List" property="og:title" />
+    <meta
+      content="The system supporting a collection of subreddits who agree to work together to limit the impact that those who have scammed"
+      property="og:description" />
+    <meta content="https://RegExrTech.github.io/tags" property="og:url" />
     <link rel="stylesheet" href="static/css/header.css" />
   </head>
 


### PR DESCRIPTION
This makes the following improves:

- Marking the language of the pages as english ensures that Google Translate and similar services will suggest auto-translations for non-english viewers
- Marking the charset as utf-8 improves page load performance substantially whenever non-ascii characters are present, since otherwise it requires a second rendering pass: https://html.spec.whatwg.org/multipage/parsing.html#encoding-sniffing-algorithm
- Adding open graph tags ensures the pages will show a preview when being linked in apps like discord, slack, iMessage, or SMS, and ensures the pages show up correctly when indexed by google search: https://ahrefs.com/blog/open-graph-meta-tags/
- Adding viewport tags dramatically improves the mobile experience, since without them the page was rendering in desktop mode (really tiny)